### PR TITLE
Expose path quoting

### DIFF
--- a/include/XdgUtils/DesktopEntry/DesktopEntryExecValue.h
+++ b/include/XdgUtils/DesktopEntry/DesktopEntryExecValue.h
@@ -48,6 +48,13 @@ namespace XdgUtils {
              */
             void remove(int pos);
 
+            /**
+             * Quote path for use in desktop entry.
+             * For use with keys like Exec, TryExec.
+             * @param string
+             */
+            static std::string quotePath(const std::string& string);
+
         private:
             struct Priv;
             std::unique_ptr<Priv> priv;

--- a/tests/DesktopEntry/TestDesktopEntryExecValue.cpp
+++ b/tests/DesktopEntry/TestDesktopEntryExecValue.cpp
@@ -55,3 +55,23 @@ TEST(TestDesktopDesktopEntryExecValue, remove) {
     ASSERT_EQ(stringList.size(), 1);
     ASSERT_EQ(stringList[0], "2");
 }
+
+TEST(TestDesktopDesktopEntryExecValue, testQuoteComplexPath) {
+    const std::string testPath = "/home/abc/Applications/a \t <>~ | % ;#()? \" b c $ `.AppImage";
+    const std::string expectedQuotedPath = "\"/home/abc/Applications/a \t <>~ | % ;#()? \\\" b c \\$ \\`.AppImage\"";
+
+    const auto quotedPath = DesktopEntryExecValue::quotePath(testPath);
+
+    std::cout << quotedPath << std::endl;
+    std::cout << expectedQuotedPath << std::endl;
+
+    EXPECT_EQ(quotedPath, expectedQuotedPath);
+}
+
+TEST(TestDesktopDesktopEntryExecValue, testQuoteSimplePath) {
+    const std::string testPath = R"(/home/abc/Applications/abc.AppImage)";
+
+    const auto quotedPath = DesktopEntryExecValue::quotePath(testPath);
+
+    EXPECT_EQ(quotedPath, testPath);
+}

--- a/tests/utils.cmake
+++ b/tests/utils.cmake
@@ -1,7 +1,7 @@
 SET(PROJECT_TESTS_TARGETS "" CACHE INTERNAL "Available tests targets")
 
-function(add_gtest name srcs)
-    add_executable(${name} ${srcs})
+function(add_gtest name)
+    add_executable(${name} ${ARGN})
     target_link_libraries(${name} GTest::GTest GTest::Main)
 
     if(${CMAKE_VERSION} VERSION_LESS "3.10.0")


### PR DESCRIPTION
This PR exposes the path quoting algorithm for external use. The same algorithm needs to be applied to other entries within libappimage (currently it is just used for `Exec` only, in the future we need to use it for `TryExec`, too). A suitable unit test is further added to make sure the algorithm works as expected.

The PR further fixes a major bug within the CMake scripts' unit test adding function, which caused all but the first files not to be added to the test executable for at least `TestXdgUtilsDesktopEntry`.